### PR TITLE
쿠폰 - 사용

### DIFF
--- a/src/main/java/com/onebook/frontapi/controller/coupon/MemberCouponController.java
+++ b/src/main/java/com/onebook/frontapi/controller/coupon/MemberCouponController.java
@@ -48,6 +48,15 @@ public class MemberCouponController {
         return "redirect:/coupon/coupon-holder";
     }
 
+    // TODO 기능 테스트용 , 추후 삭제예정 (변상우)
+    @GetMapping("/coupon/apply/test")
+    public String test1(Model model){
+
+        List<IssuedCouponResponse> list = couponBoxService.getIssuedCouponsValidForBookByMemberId(107L);
+        model.addAttribute("list",list);
+
+        return "coupon/test/test";
+    }
 
 
 }

--- a/src/main/java/com/onebook/frontapi/dto/coupon/response/coupon/IssuedCouponResponse.java
+++ b/src/main/java/com/onebook/frontapi/dto/coupon/response/coupon/IssuedCouponResponse.java
@@ -39,6 +39,4 @@ public class IssuedCouponResponse {
     private String bookIsbn13;
     private String categoryName;
 
-
-
 }

--- a/src/main/java/com/onebook/frontapi/feign/coupon/CouponBoxClient.java
+++ b/src/main/java/com/onebook/frontapi/feign/coupon/CouponBoxClient.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @FeignClient(name = "CouponBoxClient",  url = "${onebook.gatewayUrl}")
 public interface CouponBoxClient {
 
@@ -20,4 +22,8 @@ public interface CouponBoxClient {
 
     @PostMapping("/task/coupon/issue")
     ResponseEntity<IssuedCouponResponse> issueCouponToMember(@RequestBody IssueCouponToMemberRequest issueCouponToMemberRequest);
+
+    //TODO 구매할때 쿠폰적용하려고 쓰는 기능!! (해당 책에 적용가능 and 사용자가 가지고 있는 and 사용 가능한 쿠폰목록 가지고옴)
+    @GetMapping("/task/coupon/apply/{book-id}")
+    ResponseEntity<List<IssuedCouponFeignResponse>> getIssuedCouponsValidForBookByMemberId(@PathVariable(name = "book-id") Long bookId);
 }

--- a/src/main/java/com/onebook/frontapi/service/coupon/CouponBoxService.java
+++ b/src/main/java/com/onebook/frontapi/service/coupon/CouponBoxService.java
@@ -38,94 +38,11 @@ public class CouponBoxService {
         Page<IssuedCouponFeignResponse> page = couponBoxClient.getIssuedCouponsByMemberId(pageable).getBody();
 
         List<IssuedCouponResponse> issuedCouponResponseList = new ArrayList<>();
-//        Page<IssuedCouponResponse> response = new PageImpl(page.getContent());
 
         for(IssuedCouponFeignResponse issuedCouponFeignResponse :  page.getContent()){
 
-            IssuedCouponResponse issuedCouponResponse = new IssuedCouponResponse();
-
-            issuedCouponResponse.setCouponNumber(issuedCouponFeignResponse.getCouponNumber());
-            issuedCouponResponse.setIssuedCouponId(issuedCouponFeignResponse.getIssuedCouponId());
-            issuedCouponResponse.setMemberId(issuedCouponFeignResponse.getMemberId());
-            issuedCouponResponse.setIssueDateTime(issuedCouponFeignResponse.getIssueDateTime());
-            issuedCouponResponse.setUseDateTime(issuedCouponFeignResponse.getUseDateTime());
-
-            // issued 쿠폰의 쿠폰번호로 - > 쿠폰 찾아옴
-            CouponResponse couponResponse = couponClient.getCouponByCouponNumber(issuedCouponFeignResponse.getCouponNumber()).getBody();
-
-            // 쿠폰의 정책 id로 -> 정책을 찾아옴
-            if(Objects.nonNull(couponResponse.getPricePolicyForBookId())){
-
-                PricePolicyForBookResponse pricePolicyForBookResponse =
-                        couponPolicyService.getPricePolicyForBook(couponResponse.getPricePolicyForBookId());
-
-                issuedCouponResponse.setMinimumOrderAmount(pricePolicyForBookResponse.getMinimumOrderAmount());
-                issuedCouponResponse.setDiscountPrice(pricePolicyForBookResponse.getDiscountPrice());
-                issuedCouponResponse.setExpirationPeriodStart(pricePolicyForBookResponse.getExpirationPeriodStart());
-                issuedCouponResponse.setExpirationPeriodEnd(pricePolicyForBookResponse.getExpirationPeriodEnd());
-                issuedCouponResponse.setName(pricePolicyForBookResponse.getName());
-                issuedCouponResponse.setDescription(pricePolicyForBookResponse.getDescription());
-                issuedCouponResponse.setBookName(pricePolicyForBookResponse.getBookName());
-                issuedCouponResponse.setBookIsbn13(pricePolicyForBookResponse.getBookIsbn13());
-
-                issuedCouponResponse.setCouponType("pricePolicyForBook");
-
-            }
-
-            if(Objects.nonNull(couponResponse.getPricePolicyForCategoryId())){
-
-                PricePolicyForCategoryResponse pricePolicyForCategoryResponse =
-                        couponPolicyService.getPricePolicyForCategory(couponResponse.getPricePolicyForCategoryId());
-
-                issuedCouponResponse.setMinimumOrderAmount(pricePolicyForCategoryResponse.getMinimumOrderAmount());
-                issuedCouponResponse.setDiscountPrice(pricePolicyForCategoryResponse.getDiscountPrice());
-                issuedCouponResponse.setExpirationPeriodStart(pricePolicyForCategoryResponse.getExpirationPeriodStart());
-                issuedCouponResponse.setExpirationPeriodEnd(pricePolicyForCategoryResponse.getExpirationPeriodEnd());
-                issuedCouponResponse.setName(pricePolicyForCategoryResponse.getName());
-                issuedCouponResponse.setDescription(pricePolicyForCategoryResponse.getDescription());
-                issuedCouponResponse.setCategoryName(pricePolicyForCategoryResponse.getCategoryName());
-
-                issuedCouponResponse.setCouponType("pricePolicyForCategory");
-
-            }
-
-            if(Objects.nonNull(couponResponse.getRatePolicyForBookId())){
-
-                RatePolicyForBookResponse ratePolicyForBookResponse =
-                        couponPolicyService.getRatePolicyForBook(couponResponse.getRatePolicyForBookId());
-
-                issuedCouponResponse.setMinimumOrderAmount(ratePolicyForBookResponse.getMinimumOrderAmount());
-                issuedCouponResponse.setDiscountRate(ratePolicyForBookResponse.getDiscountRate());
-                issuedCouponResponse.setMaximumDiscountPrice(ratePolicyForBookResponse.getMaximumDiscountPrice());
-                issuedCouponResponse.setExpirationPeriodStart(ratePolicyForBookResponse.getExpirationPeriodStart());
-                issuedCouponResponse.setExpirationPeriodEnd(ratePolicyForBookResponse.getExpirationPeriodEnd());
-                issuedCouponResponse.setName(ratePolicyForBookResponse.getName());
-                issuedCouponResponse.setDescription(ratePolicyForBookResponse.getDescription());
-                issuedCouponResponse.setBookName(ratePolicyForBookResponse.getBookName());
-                issuedCouponResponse.setBookIsbn13(ratePolicyForBookResponse.getBookIsbn13());
-
-                issuedCouponResponse.setCouponType("ratePolicyForBook");
-
-            }
-
-            if(Objects.nonNull(couponResponse.getRatePolicyForCategoryId())){
-
-                RatePolicyForCategoryResponse ratePolicyForCategoryResponse =
-                        couponPolicyService.getRatePolicyForCategory(couponResponse.getRatePolicyForCategoryId());
-
-                issuedCouponResponse.setMinimumOrderAmount(ratePolicyForCategoryResponse.getMinimumOrderAmount());
-                issuedCouponResponse.setDiscountRate(ratePolicyForCategoryResponse.getDiscountRate());
-                issuedCouponResponse.setMaximumDiscountPrice(ratePolicyForCategoryResponse.getMaximumDiscountPrice());
-                issuedCouponResponse.setExpirationPeriodStart(ratePolicyForCategoryResponse.getExpirationPeriodStart());
-                issuedCouponResponse.setExpirationPeriodEnd(ratePolicyForCategoryResponse.getExpirationPeriodEnd());
-                issuedCouponResponse.setName(ratePolicyForCategoryResponse.getName());
-                issuedCouponResponse.setDescription(ratePolicyForCategoryResponse.getDescription());
-                issuedCouponResponse.setCategoryName(ratePolicyForCategoryResponse.getCategoryName());
-
-                issuedCouponResponse.setCouponType("ratePolicyForCategory");
-
-            }
-
+            // 단순 IssuedCouponResponse들을 정책 정보까지 담은 정보로 변환해줌
+            IssuedCouponResponse issuedCouponResponse = makeIssuedCouponResponseContainingPolicyInfo(issuedCouponFeignResponse);
             issuedCouponResponseList.add(issuedCouponResponse);
         }
 
@@ -134,8 +51,8 @@ public class CouponBoxService {
                 new PageImpl<>(issuedCouponResponseList,pageable,page.getTotalPages());
 
             return issuedCouponResponsePage;
-
     }
+
 
     public IssuedCouponResponse issueCoupon(FindCouponsByPolicyIdRequest findCouponsByPolicyIdRequest){
 
@@ -171,6 +88,116 @@ public class CouponBoxService {
         IssueCouponToMemberRequest issueCouponToMemberRequest = new IssueCouponToMemberRequest(couponNumber);
 
         return couponBoxClient.issueCouponToMember(issueCouponToMemberRequest).getBody();
+    }
+
+    //TODO 구매할때 쿠폰적용하려고 쓰는 기능!! (해당 책에 적용가능 and 사용자가 가지고 있는 and 사용 가능한 쿠폰목록 가지고옴)
+    public List<IssuedCouponResponse> getIssuedCouponsValidForBookByMemberId(Long bookId){
+
+        List<IssuedCouponFeignResponse> issuedCouponResponseList =
+                couponBoxClient.getIssuedCouponsValidForBookByMemberId(bookId).getBody();
+
+        if(issuedCouponResponseList == null || issuedCouponResponseList.isEmpty()){
+            // 조건에 맞는 사용자의 쿠폰이 없다면 빈 arrayList 리턴
+            return new ArrayList<>();
+        }
+        else{
+         return issuedCouponResponseList.stream().map(this::makeIssuedCouponResponseContainingPolicyInfo).toList();
+        }
+    }
+
+
+
+    public CouponResponse getCouponByCouponNumber(String couponNumber){
+        return couponClient.getCouponByCouponNumber(couponNumber).getBody();
+    }
+
+    private IssuedCouponResponse makeIssuedCouponResponseContainingPolicyInfo(IssuedCouponFeignResponse issuedCouponFeignResponse){
+
+
+        IssuedCouponResponse issuedCouponResponse = new IssuedCouponResponse();
+
+        issuedCouponResponse.setCouponNumber(issuedCouponFeignResponse.getCouponNumber());
+        issuedCouponResponse.setIssuedCouponId(issuedCouponFeignResponse.getIssuedCouponId());
+        issuedCouponResponse.setMemberId(issuedCouponFeignResponse.getMemberId());
+        issuedCouponResponse.setIssueDateTime(issuedCouponFeignResponse.getIssueDateTime());
+        issuedCouponResponse.setUseDateTime(issuedCouponFeignResponse.getUseDateTime());
+
+        CouponResponse couponResponse = getCouponByCouponNumber(issuedCouponFeignResponse.getCouponNumber());
+
+        // 쿠폰의 정책 id로 -> 정책을 찾아옴
+        if(Objects.nonNull(couponResponse.getPricePolicyForBookId())){
+
+            PricePolicyForBookResponse pricePolicyForBookResponse =
+                    couponPolicyService.getPricePolicyForBook(couponResponse.getPricePolicyForBookId());
+
+            issuedCouponResponse.setMinimumOrderAmount(pricePolicyForBookResponse.getMinimumOrderAmount());
+            issuedCouponResponse.setDiscountPrice(pricePolicyForBookResponse.getDiscountPrice());
+            issuedCouponResponse.setExpirationPeriodStart(pricePolicyForBookResponse.getExpirationPeriodStart());
+            issuedCouponResponse.setExpirationPeriodEnd(pricePolicyForBookResponse.getExpirationPeriodEnd());
+            issuedCouponResponse.setName(pricePolicyForBookResponse.getName());
+            issuedCouponResponse.setDescription(pricePolicyForBookResponse.getDescription());
+            issuedCouponResponse.setBookName(pricePolicyForBookResponse.getBookName());
+            issuedCouponResponse.setBookIsbn13(pricePolicyForBookResponse.getBookIsbn13());
+
+            issuedCouponResponse.setCouponType("pricePolicyForBook");
+
+        }
+
+        if(Objects.nonNull(couponResponse.getPricePolicyForCategoryId())){
+
+            PricePolicyForCategoryResponse pricePolicyForCategoryResponse =
+                    couponPolicyService.getPricePolicyForCategory(couponResponse.getPricePolicyForCategoryId());
+
+            issuedCouponResponse.setMinimumOrderAmount(pricePolicyForCategoryResponse.getMinimumOrderAmount());
+            issuedCouponResponse.setDiscountPrice(pricePolicyForCategoryResponse.getDiscountPrice());
+            issuedCouponResponse.setExpirationPeriodStart(pricePolicyForCategoryResponse.getExpirationPeriodStart());
+            issuedCouponResponse.setExpirationPeriodEnd(pricePolicyForCategoryResponse.getExpirationPeriodEnd());
+            issuedCouponResponse.setName(pricePolicyForCategoryResponse.getName());
+            issuedCouponResponse.setDescription(pricePolicyForCategoryResponse.getDescription());
+            issuedCouponResponse.setCategoryName(pricePolicyForCategoryResponse.getCategoryName());
+
+            issuedCouponResponse.setCouponType("pricePolicyForCategory");
+
+        }
+
+        if(Objects.nonNull(couponResponse.getRatePolicyForBookId())){
+
+            RatePolicyForBookResponse ratePolicyForBookResponse =
+                    couponPolicyService.getRatePolicyForBook(couponResponse.getRatePolicyForBookId());
+
+            issuedCouponResponse.setMinimumOrderAmount(ratePolicyForBookResponse.getMinimumOrderAmount());
+            issuedCouponResponse.setDiscountRate(ratePolicyForBookResponse.getDiscountRate());
+            issuedCouponResponse.setMaximumDiscountPrice(ratePolicyForBookResponse.getMaximumDiscountPrice());
+            issuedCouponResponse.setExpirationPeriodStart(ratePolicyForBookResponse.getExpirationPeriodStart());
+            issuedCouponResponse.setExpirationPeriodEnd(ratePolicyForBookResponse.getExpirationPeriodEnd());
+            issuedCouponResponse.setName(ratePolicyForBookResponse.getName());
+            issuedCouponResponse.setDescription(ratePolicyForBookResponse.getDescription());
+            issuedCouponResponse.setBookName(ratePolicyForBookResponse.getBookName());
+            issuedCouponResponse.setBookIsbn13(ratePolicyForBookResponse.getBookIsbn13());
+
+            issuedCouponResponse.setCouponType("ratePolicyForBook");
+
+        }
+
+        if(Objects.nonNull(couponResponse.getRatePolicyForCategoryId())){
+
+            RatePolicyForCategoryResponse ratePolicyForCategoryResponse =
+                    couponPolicyService.getRatePolicyForCategory(couponResponse.getRatePolicyForCategoryId());
+
+            issuedCouponResponse.setMinimumOrderAmount(ratePolicyForCategoryResponse.getMinimumOrderAmount());
+            issuedCouponResponse.setDiscountRate(ratePolicyForCategoryResponse.getDiscountRate());
+            issuedCouponResponse.setMaximumDiscountPrice(ratePolicyForCategoryResponse.getMaximumDiscountPrice());
+            issuedCouponResponse.setExpirationPeriodStart(ratePolicyForCategoryResponse.getExpirationPeriodStart());
+            issuedCouponResponse.setExpirationPeriodEnd(ratePolicyForCategoryResponse.getExpirationPeriodEnd());
+            issuedCouponResponse.setName(ratePolicyForCategoryResponse.getName());
+            issuedCouponResponse.setDescription(ratePolicyForCategoryResponse.getDescription());
+            issuedCouponResponse.setCategoryName(ratePolicyForCategoryResponse.getCategoryName());
+
+            issuedCouponResponse.setCouponType("ratePolicyForCategory");
+
+        }
+
+        return issuedCouponResponse;
     }
 
 }

--- a/src/main/resources/templates/coupon/test/test.html
+++ b/src/main/resources/templates/coupon/test/test.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+
+<div th:each=" element : ${list}">
+
+    <h1 th:text="${element.getCouponNumber()}"></h1>
+    <h1 th:text="${element.getName()}"></h1>
+
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
사용자가 주문시 사용가능한 쿠폰들을 불러옵니다.
가져와지는 쿠폰들은
- 사용자가 가지고 있으며 (사용자의 쿠폰함에 존재하며)
- 유효기간이 지나지 않은 (정책의 유효기간)
- 사용하지 않은 (쿠폰의 useDateTime이 null이고 쿠폰상태가 '발급-삭제가능'
- 해당 도서에 적용가능한 모든 쿠폰들입니다

추후에 만약 쿠폰이 적용로직이 만들어진다면
쿠폰 적용로직은
useDateTime을 채워주고, 쿠폰상태가 '발급-삭제불가' 로 변경하는것을
포함해야합니다